### PR TITLE
Replace GPL header with MIT in nested HeiOrient random.h

### DIFF
--- a/extern/optimal_codes/HeiOrient/utils/random.h
+++ b/extern/optimal_codes/HeiOrient/utils/random.h
@@ -1,21 +1,27 @@
 /*******************************************************************************
- * This file was part of KaHyPar.
+ * MIT License
+ *
+ * This file is part of KaHyPar.
  *
  * Copyright (C) 2014-2016 Sebastian Schlag <sebastian.schlag@kit.edu>
  *
- * KaHyPar is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * KaHyPar is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * You should have received a copy of the GNU General Public License
- * along with KaHyPar.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
  ******************************************************************************/
 #pragma once
 


### PR DESCRIPTION
## Summary
- `extern/optimal_codes/HeiOrient/utils/random.h` carried a stale GPL v3 header from KaHyPar
- The upstream KaHyPar source (`kahypar-shared-resources/randomize.h`) is MIT-licensed
- Replaced the GPL header with MIT, preserving original copyright (Sebastian Schlag, 2014-2016)

## Test plan
- [x] Verified zero GPL references remain in source files
- [ ] No functional code changes — only license header text replaced